### PR TITLE
gl_client: fcommon,(prelim) custom CC support, multiple definitions error fix on GCC11+ 

### DIFF
--- a/common/utils.h
+++ b/common/utils.h
@@ -11,20 +11,20 @@ ANativeWindow* glsurfaceview_window;
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 
-Display *xDisplay;
-int xScreenId;
+static Display *xDisplay;
+static int xScreenId;
 #if defined(GLS_SERVER) || !defined(USE_SERVER_SIZE)
-Window xWindow;
+static Window xWindow;
 #endif // GLS_SERVER || !USE_SERVER_SIZE
 
 #endif // USE_X11
 
 #ifdef GLS_SERVER
-int glsurfaceview_width;
-int glsurfaceview_height;
+static int glsurfaceview_width;
+static int glsurfaceview_height;
 
-int   var_server_port;
-int   var_client_port;
+static int   var_server_port;
+static int   var_client_port;
 const char* var_client_addr;
 /*
 const char* var_path_shadercache;

--- a/gl_client/Makefile
+++ b/gl_client/Makefile
@@ -1,4 +1,5 @@
-CFLAGS=-O3 -Wall -I../common -I. -I./include -fPIC -g
+CC ?= gcc
+CFLAGS=-O3 -Wall -I../common -I. -I./include -fPIC -g -fcommon -L/usr/include
 
 # Use X11
 CFLAGS+=-DUSE_X11
@@ -22,22 +23,22 @@ EXES=$(LIB_GLES)
 all: $(EXES)
 
 fifo.o: ../common/fifo.c ../common/fifo.h
-	gcc -c -o fifo.o $(CFLAGS) ../common/fifo.c
+	$(CC) -c -o fifo.o $(CFLAGS) ../common/fifo.c
 
 server.o: ../common/server.c ../common/server.h fifo.o
-	gcc -c -o server.o $(CFLAGS) ../common/server.c
+	$(CC) -c -o server.o $(CFLAGS) ../common/server.c
 
 clientegl.o: clientegl.c include/EGL/egl.h
-	gcc -c -o clientegl.o $(CFLAGS) clientegl.c
+	$(CC) -c -o clientegl.o $(CFLAGS) clientegl.c
 
 clientgles.o: clientgles.c include/GLES2/gl2.h
-	gcc -c -o clientgles.o $(CFLAGS) clientgles.c
+	$(CC) -c -o clientgles.o $(CFLAGS) clientgles.c
 
 glclient.o: glclient.c glclient.h ../common/gls_command.h server.o
-	gcc -c -o glclient.o $(CFLAGS) glclient.c
+	$(CC) -c -o glclient.o $(CFLAGS) glclient.c
 
 $(LIB_GLES): $(OBJS)
-	gcc -shared -o $(LIB_GLES) $(CFLAGS) $(OBJS) -Wl,-init,gls_init_library,--no-undefined $(LIBS)
+	$(CC) -shared -o $(LIB_GLES) $(CFLAGS) $(OBJS) -Wl,-init,gls_init_library,--no-undefined $(LIBS)
 
 install:
 	mkdir -p $(GLS_LIB_DIR)


### PR DESCRIPTION
gl_client: Added custom CC support in makefile (primarily aimed to ease cross compile)
gl_client: Fixed multiple definitions error during link time (only GCC11 and above - tested on GCC11 only)